### PR TITLE
Bugfix/disable buttons on choice

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -1,5 +1,6 @@
 import request from 'superagent'
 import { createBreedAndSubBreedList, createNextQuestion, sleep } from '../lib/utils'
+import { activateButtons, disableButtons } from './buttons'
 
 export const SET_BREEDLIST = 'SET_BREEDLIST'
 export const GAME_STARTED = 'GAME_STARTED'
@@ -44,7 +45,13 @@ export const nextQuestionCreated = (question) => ({
 
 export const nextQuestion = (delay) => {
     return async (dispatch, getState) => {
-        const { currentBreeds, correctAnswer } = createNextQuestion(getState().question.currentBreeds)
+        const state = getState()
+
+        if(state.buttons.active){
+            dispatch(disableButtons())
+        }
+
+        const { currentBreeds, correctAnswer } = createNextQuestion(state.question.currentBreeds)
         const imageUrl = await fetchRandomImageFromBreed(correctAnswer)
 
         if(delay){
@@ -52,5 +59,6 @@ export const nextQuestion = (delay) => {
         }
         
         dispatch(nextQuestionCreated({ currentBreeds, correctAnswer, imageUrl }))
+        dispatch(activateButtons())
     }
 } 

--- a/src/actions/buttons.js
+++ b/src/actions/buttons.js
@@ -1,0 +1,6 @@
+export const BUTTONS_ACTIVE = 'BUTTONS_ACTIVE'
+export const BUTTONS_DISABLED = 'BUTTONS_DISABLED'
+
+export const activateButtons = () => ({ type: BUTTONS_ACTIVE })
+export const disableButtons = () => ({ type: BUTTONS_DISABLED })
+

--- a/src/actions/feedback.js
+++ b/src/actions/feedback.js
@@ -1,5 +1,6 @@
 import { sleep } from '../lib/utils'
 import { nextQuestion } from './api'
+import { disableButtons } from './buttons'
 
 export const SHOW_FEEDBACK = 'SHOW_FEEDBACK'
 export const HIDE_FEEDBACK = 'HIDE_FEEDBACK'
@@ -14,6 +15,7 @@ export const showFeedback = () => ({
 
 export const showFeedbackThenNextQuestion = () => {
     return async (dispatch, getState) => {
+        dispatch(disableButtons())
         await sleep(ONE_THIRD_OF_A_SECOND)
         dispatch(showFeedback())
         await sleep(TWO_SECONDS)

--- a/src/containers/AnswerButton.js
+++ b/src/containers/AnswerButton.js
@@ -25,9 +25,10 @@ class AnswerButton extends React.Component {
     }
 
     render() {
-        const { option } = this.props
+        const { option, buttonsActive } = this.props
         return (
             <button 
+                disabled={!buttonsActive}
                 key={option}
                 onClick={this.checkAnswer} 
                 className="button" 
@@ -40,6 +41,7 @@ class AnswerButton extends React.Component {
 }
 
 const mapStateToProps = (state) => ({
+    buttonsActive: state.buttons.active,
     displayFeedback: state.feedback.displayFeedback
 })
 

--- a/src/css/button.css
+++ b/src/css/button.css
@@ -11,10 +11,16 @@
 }
 
 .button:hover {
-    transform: translateY(-5px)
+    transform: translateY(-5px);
+    background: linear-gradient(180deg, #FFFFFF 0%, rgba(255, 255, 255, 0.635417) 52.6%, rgba(255, 255, 255, 0) 100%), #F74CFA;
 }
 
 .button:active {
     box-shadow: none;
     transform: rotate(10deg)
+}
+
+.button:disabled {
+    transform: translateY(0px);
+    background: linear-gradient(180deg, #FFFFFF 0%, rgba(255, 255, 255, 0.635417) 52.6%, rgba(255, 255, 255, 0) 100%), #C419C7;
 }

--- a/src/css/button.css
+++ b/src/css/button.css
@@ -8,6 +8,7 @@
     margin: 2vh 2vw;
     padding: 10px;
     transition: 0.3s;
+    box-shadow: 10px 11px 36px -6px rgba(0,0,0,0.75);
 }
 
 .button:hover {

--- a/src/css/dog.css
+++ b/src/css/dog.css
@@ -3,4 +3,5 @@
     box-sizing: border-box;
     border-radius: 5px;
     transform: rotate(-10deg);
+    box-shadow: 10px 11px 36px -6px rgba(0,0,0,0.75);
 }

--- a/src/reducers/buttons.js
+++ b/src/reducers/buttons.js
@@ -1,0 +1,20 @@
+import { BUTTONS_ACTIVE, BUTTONS_DISABLED } from "../actions/buttons";
+
+const initialState = { active: false }
+
+export default (state = initialState, action = {}) => {
+    switch (action.type) {
+        case BUTTONS_ACTIVE: {
+            return { ...state, active: true}
+        }
+
+        case BUTTONS_DISABLED: {
+            return { ...state, active: false}
+        }
+            
+        default:{
+            return state
+        }
+    }
+}
+

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,10 +1,12 @@
 import { combineReducers } from 'redux'
 import breeds from './breeds'
+import buttons from './buttons'
 import feedback from './feedback'
 import question from './question'
 
 export default combineReducers({
     breeds,
+    buttons,
     feedback,
     question
 })


### PR DESCRIPTION
# What this pullrequest does:

When the user had submitted an answer you could still press the buttons creating another new question.
This PR prevents this from happening

- Disables buttons when a user has submitted an answer
- Adds visual ques to let the user know the buttons are disabled

![Mar-10-2019 19-15-05](https://user-images.githubusercontent.com/20372832/54089423-fa821680-4368-11e9-8009-af61a80f9330.gif)